### PR TITLE
Auto-smelt XP drop & Exclusivity with Silk Touch

### DIFF
--- a/data/enchantplus/enchantment/tools/auto_smelt.json
+++ b/data/enchantplus/enchantment/tools/auto_smelt.json
@@ -5,16 +5,6 @@
         "fallback": "Auto Smelt"
     },
     "exclusive_set": "minecraft:silk_touch",
-    "effects": {
-        "minecraft:block_experience": [
-            {
-                "effect": {
-                    "type": "minecraft:set",
-                    "value": 0
-                }
-            }
-        ]
-    },
     "max_cost": {
         "base": 65,
         "per_level_above_first": 0

--- a/data/enchantplus/enchantment/tools/auto_smelt.json
+++ b/data/enchantplus/enchantment/tools/auto_smelt.json
@@ -4,6 +4,7 @@
         "translate": "enchantment.enchantplus.auto_smelt",
         "fallback": "Auto Smelt"
     },
+    "exclusive_set": "minecraft:silk_touch",
     "effects": {
         "minecraft:block_experience": [
             {

--- a/data/enchantplus/function/actions/auto_smelt_xp.mcfunction
+++ b/data/enchantplus/function/actions/auto_smelt_xp.mcfunction
@@ -1,0 +1,4 @@
+summon experience_orb ~ ~ ~ {Value:0}
+data modify entity @n[type=minecraft:experience_orb,nbt={Value:0s}] Count set from entity @s Item.count
+data modify entity @n[type=minecraft:experience_orb,nbt={Value:0s}] Value set from entity @s Item.components."minecraft:custom_data".auto_smelt_xp
+data remove entity @s Item.components."minecraft:custom_data"

--- a/data/enchantplus/function/main.mcfunction
+++ b/data/enchantplus/function/main.mcfunction
@@ -17,3 +17,5 @@ execute if score #hit_block_markers enchantplus.data matches 1.. as @e[type=mark
 # Fear enchantment prevent TNT and creeper explosions
 execute at @a[predicate=enchantplus:enchantments/fear] run function enchantplus:fear/tick
 
+# Auto-smelt XP
+execute as @e[type=item,nbt={Item:{components:{"minecraft:custom_data":{auto_smelt_drops_xp:true}}}}] at @s run function enchantplus:actions/auto_smelt_xp

--- a/data/minecraft/loot_table/blocks/acacia_log.json
+++ b/data/minecraft/loot_table/blocks/acacia_log.json
@@ -2,10 +2,12 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
-      "conditions": [
+      "rolls": 1,
+      "bonus_rolls": 0,
+      "entries": [
         {
-          "condition": "minecraft:survives_explosion"
+          "type": "minecraft:item",
+          "name": "minecraft:acacia_log"
         }
       ],
       "functions": [
@@ -28,15 +30,43 @@
               }
             }
           ]
-        }
-      ],
-      "entries": [
+        },
         {
-          "type": "minecraft:item",
-          "name": "minecraft:acacia_log"
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
-      "rolls": 1.0
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
     }
   ],
   "random_sequence": "minecraft:blocks/acacia_log"

--- a/data/minecraft/loot_table/blocks/acacia_log.json
+++ b/data/minecraft/loot_table/blocks/acacia_log.json
@@ -2,12 +2,10 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
-      "bonus_rolls": 0,
-      "entries": [
+      "bonus_rolls": 0.0,
+      "conditions": [
         {
-          "type": "minecraft:item",
-          "name": "minecraft:acacia_log"
+          "condition": "minecraft:survives_explosion"
         }
       ],
       "functions": [
@@ -62,11 +60,13 @@
           ]
         }
       ],
-      "conditions": [
+      "entries": [
         {
-          "condition": "minecraft:survives_explosion"
+          "type": "minecraft:item",
+          "name": "minecraft:acacia_log"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
   ],
   "random_sequence": "minecraft:blocks/acacia_log"

--- a/data/minecraft/loot_table/blocks/acacia_wood.json
+++ b/data/minecraft/loot_table/blocks/acacia_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/ancient_debris.json
+++ b/data/minecraft/loot_table/blocks/ancient_debris.json
@@ -28,6 +28,32 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 2
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/basalt.json
+++ b/data/minecraft/loot_table/blocks/basalt.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/birch_log.json
+++ b/data/minecraft/loot_table/blocks/birch_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/birch_wood.json
+++ b/data/minecraft/loot_table/blocks/birch_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/black_terracotta.json
+++ b/data/minecraft/loot_table/blocks/black_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/blue_terracotta.json
+++ b/data/minecraft/loot_table/blocks/blue_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/brown_terracotta.json
+++ b/data/minecraft/loot_table/blocks/brown_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/cactus.json
+++ b/data/minecraft/loot_table/blocks/cactus.json
@@ -28,6 +28,32 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/cherry_log.json
+++ b/data/minecraft/loot_table/blocks/cherry_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/cherry_wood.json
+++ b/data/minecraft/loot_table/blocks/cherry_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/clay.json
+++ b/data/minecraft/loot_table/blocks/clay.json
@@ -58,6 +58,36 @@
                       }
                     }
                   ]
+                },
+                {
+                  "function": "minecraft:set_components",
+                  "components": {
+                    "minecraft:custom_data": {
+                      "auto_smelt_drops_xp": true,
+                      "auto_smelt_xp": 1
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "enchantplus:tools/auto_smelt",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "condition": "minecraft:random_chance",
+                      "chance": 0.3
+                    }
+                  ]
                 }
               ],
               "name": "minecraft:clay_ball"

--- a/data/minecraft/loot_table/blocks/cobbled_deepslate.json
+++ b/data/minecraft/loot_table/blocks/cobbled_deepslate.json
@@ -28,6 +28,36 @@
                             }
                         }
                     ]
+                },
+                {
+                  "function": "minecraft:set_components",
+                  "components": {
+                    "minecraft:custom_data": {
+                      "auto_smelt_drops_xp": true,
+                      "auto_smelt_xp": 1
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "enchantplus:tools/auto_smelt",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "condition": "minecraft:random_chance",
+                      "chance": 0.1
+                    }
+                  ]
                 }
             ],
             "entries": [

--- a/data/minecraft/loot_table/blocks/cobblestone.json
+++ b/data/minecraft/loot_table/blocks/cobblestone.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/copper_ore.json
+++ b/data/minecraft/loot_table/blocks/copper_ore.json
@@ -52,6 +52,36 @@
                   ]
                 },
                 {
+                  "function": "minecraft:set_components",
+                  "components": {
+                    "minecraft:custom_data": {
+                      "auto_smelt_drops_xp": true,
+                      "auto_smelt_xp": 1
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "enchantplus:tools/auto_smelt",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "condition": "minecraft:random_chance",
+                      "chance": 0.7
+                    }
+                  ]
+                },
+                {
                   "add": false,
                   "count": {
                     "type": "minecraft:uniform",

--- a/data/minecraft/loot_table/blocks/cyan_terracotta.json
+++ b/data/minecraft/loot_table/blocks/cyan_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/dark_oak_log.json
+++ b/data/minecraft/loot_table/blocks/dark_oak_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/dark_oak_wood.json
+++ b/data/minecraft/loot_table/blocks/dark_oak_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/deepslate_bricks.json
+++ b/data/minecraft/loot_table/blocks/deepslate_bricks.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/deepslate_copper_ore.json
+++ b/data/minecraft/loot_table/blocks/deepslate_copper_ore.json
@@ -52,6 +52,36 @@
                   ]
                 },
                 {
+                  "function": "minecraft:set_components",
+                  "components": {
+                    "minecraft:custom_data": {
+                      "auto_smelt_drops_xp": true,
+                      "auto_smelt_xp": 1
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "enchantplus:tools/auto_smelt",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "condition": "minecraft:random_chance",
+                      "chance": 0.7
+                    }
+                  ]
+                },
+                {
                   "add": false,
                   "count": {
                     "type": "minecraft:uniform",

--- a/data/minecraft/loot_table/blocks/deepslate_gold_ore.json
+++ b/data/minecraft/loot_table/blocks/deepslate_gold_ore.json
@@ -52,6 +52,32 @@
                   ]
                 },
                 {
+                  "function": "minecraft:set_components",
+                  "components": {
+                    "minecraft:custom_data": {
+                      "auto_smelt_drops_xp": true,
+                      "auto_smelt_xp": 1
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "enchantplus:tools/auto_smelt",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
                   "enchantment": "minecraft:fortune",
                   "formula": "minecraft:ore_drops",
                   "function": "minecraft:apply_bonus"

--- a/data/minecraft/loot_table/blocks/deepslate_iron_ore.json
+++ b/data/minecraft/loot_table/blocks/deepslate_iron_ore.json
@@ -52,6 +52,36 @@
                   ]
                 },
                 {
+                  "function": "minecraft:set_components",
+                  "components": {
+                    "minecraft:custom_data": {
+                      "auto_smelt_drops_xp": true,
+                      "auto_smelt_xp": 1
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "enchantplus:tools/auto_smelt",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "condition": "minecraft:random_chance",
+                      "chance": 0.7
+                    }
+                  ]
+                },
+                {
                   "enchantment": "minecraft:fortune",
                   "formula": "minecraft:ore_drops",
                   "function": "minecraft:apply_bonus"

--- a/data/minecraft/loot_table/blocks/gold_ore.json
+++ b/data/minecraft/loot_table/blocks/gold_ore.json
@@ -52,6 +52,32 @@
                   ]
                 },
                 {
+                  "function": "minecraft:set_components",
+                  "components": {
+                    "minecraft:custom_data": {
+                      "auto_smelt_drops_xp": true,
+                      "auto_smelt_xp": 1
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "enchantplus:tools/auto_smelt",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
                   "enchantment": "minecraft:fortune",
                   "formula": "minecraft:ore_drops",
                   "function": "minecraft:apply_bonus"

--- a/data/minecraft/loot_table/blocks/gray_terracotta.json
+++ b/data/minecraft/loot_table/blocks/gray_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/green_terracotta.json
+++ b/data/minecraft/loot_table/blocks/green_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/iron_ore.json
+++ b/data/minecraft/loot_table/blocks/iron_ore.json
@@ -57,6 +57,36 @@
                   ]
                 },
                 {
+                  "function": "minecraft:set_components",
+                  "components": {
+                    "minecraft:custom_data": {
+                      "auto_smelt_drops_xp": true,
+                      "auto_smelt_xp": 1
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "enchantplus:tools/auto_smelt",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "condition": "minecraft:random_chance",
+                      "chance": 0.7
+                    }
+                  ]
+                },
+                {
                   "function": "minecraft:explosion_decay"
                 }
               ],

--- a/data/minecraft/loot_table/blocks/jungle_log.json
+++ b/data/minecraft/loot_table/blocks/jungle_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/jungle_wood.json
+++ b/data/minecraft/loot_table/blocks/jungle_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/light_blue_terracotta.json
+++ b/data/minecraft/loot_table/blocks/light_blue_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/light_gray_terracotta.json
+++ b/data/minecraft/loot_table/blocks/light_gray_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/lime_terracotta.json
+++ b/data/minecraft/loot_table/blocks/lime_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/magenta_terracotta.json
+++ b/data/minecraft/loot_table/blocks/magenta_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/mangrove_log.json
+++ b/data/minecraft/loot_table/blocks/mangrove_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/mangrove_wood.json
+++ b/data/minecraft/loot_table/blocks/mangrove_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/nether_bricks.json
+++ b/data/minecraft/loot_table/blocks/nether_bricks.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/netherrack.json
+++ b/data/minecraft/loot_table/blocks/netherrack.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/oak_log.json
+++ b/data/minecraft/loot_table/blocks/oak_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/oak_wood.json
+++ b/data/minecraft/loot_table/blocks/oak_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/orange_terracotta.json
+++ b/data/minecraft/loot_table/blocks/orange_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/pink_terracotta.json
+++ b/data/minecraft/loot_table/blocks/pink_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/polished_blackstone_bricks.json
+++ b/data/minecraft/loot_table/blocks/polished_blackstone_bricks.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/purple_terracotta.json
+++ b/data/minecraft/loot_table/blocks/purple_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/quartz_block.json
+++ b/data/minecraft/loot_table/blocks/quartz_block.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/red_sand.json
+++ b/data/minecraft/loot_table/blocks/red_sand.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/red_sandstone.json
+++ b/data/minecraft/loot_table/blocks/red_sandstone.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/red_terracotta.json
+++ b/data/minecraft/loot_table/blocks/red_terracotta.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/sand.json
+++ b/data/minecraft/loot_table/blocks/sand.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/sandstone.json
+++ b/data/minecraft/loot_table/blocks/sandstone.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/sea_pickle.json
+++ b/data/minecraft/loot_table/blocks/sea_pickle.json
@@ -28,6 +28,36 @@
               ]
             },
             {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:custom_data": {
+                  "auto_smelt_drops_xp": true,
+                  "auto_smelt_xp": 1
+                }
+              },
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "enchantplus:tools/auto_smelt",
+                          "levels": {
+                            "min": 1
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.1
+                }
+              ]
+            },
+            {
               "add": false,
               "conditions": [
                 {

--- a/data/minecraft/loot_table/blocks/spruce_log.json
+++ b/data/minecraft/loot_table/blocks/spruce_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/spruce_wood.json
+++ b/data/minecraft/loot_table/blocks/spruce_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stone.json
+++ b/data/minecraft/loot_table/blocks/stone.json
@@ -50,6 +50,36 @@
                       }
                     }
                   ]
+                },
+                {
+                  "function": "minecraft:set_components",
+                  "components": {
+                    "minecraft:custom_data": {
+                      "auto_smelt_drops_xp": true,
+                      "auto_smelt_xp": 1
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "enchantplus:tools/auto_smelt",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "condition": "minecraft:random_chance",
+                      "chance": 0.1
+                    }
+                  ]
                 }
               ],
               "conditions": [

--- a/data/minecraft/loot_table/blocks/stone_bricks.json
+++ b/data/minecraft/loot_table/blocks/stone_bricks.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_acacia_log.json
+++ b/data/minecraft/loot_table/blocks/stripped_acacia_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_acacia_wood.json
+++ b/data/minecraft/loot_table/blocks/stripped_acacia_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_birch_log.json
+++ b/data/minecraft/loot_table/blocks/stripped_birch_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_birch_wood.json
+++ b/data/minecraft/loot_table/blocks/stripped_birch_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_cherry_log.json
+++ b/data/minecraft/loot_table/blocks/stripped_cherry_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_cherry_wood.json
+++ b/data/minecraft/loot_table/blocks/stripped_cherry_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_dark_oak_log.json
+++ b/data/minecraft/loot_table/blocks/stripped_dark_oak_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_dark_oak_wood.json
+++ b/data/minecraft/loot_table/blocks/stripped_dark_oak_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_jungle_log.json
+++ b/data/minecraft/loot_table/blocks/stripped_jungle_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_jungle_wood.json
+++ b/data/minecraft/loot_table/blocks/stripped_jungle_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_mangrove_log.json
+++ b/data/minecraft/loot_table/blocks/stripped_mangrove_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_mangrove_wood.json
+++ b/data/minecraft/loot_table/blocks/stripped_mangrove_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_oak_log.json
+++ b/data/minecraft/loot_table/blocks/stripped_oak_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_oak_wood.json
+++ b/data/minecraft/loot_table/blocks/stripped_oak_wood.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_spruce_log.json
+++ b/data/minecraft/loot_table/blocks/stripped_spruce_log.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/stripped_spruce_wood.json
+++ b/data/minecraft/loot_table/blocks/stripped_spruce_wood.json
@@ -30,6 +30,36 @@
                             }
                         }
                     ]
+                },
+                {
+                  "function": "minecraft:set_components",
+                  "components": {
+                    "minecraft:custom_data": {
+                      "auto_smelt_drops_xp": true,
+                      "auto_smelt_xp": 1
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "enchantplus:tools/auto_smelt",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "condition": "minecraft:random_chance",
+                      "chance": 0.15
+                    }
+                  ]
                 }
             ],
             "conditions": [

--- a/data/minecraft/loot_table/blocks/wet_sponge.json
+++ b/data/minecraft/loot_table/blocks/wet_sponge.json
@@ -28,6 +28,36 @@
               }
             }
           ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.15
+            }
+          ]
         }
       ],
       "entries": [

--- a/data/minecraft/loot_table/blocks/white_terracotta.json
+++ b/data/minecraft/loot_table/blocks/white_terracotta.json
@@ -8,6 +8,58 @@
           "condition": "minecraft:survives_explosion"
         }
       ],
+      "functions": [
+        {
+          "function": "minecraft:furnace_smelt",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
+        }
+      ],
       "entries": [
         {
           "type": "minecraft:item",

--- a/data/minecraft/loot_table/blocks/yellow_terracotta.json
+++ b/data/minecraft/loot_table/blocks/yellow_terracotta.json
@@ -8,6 +8,58 @@
           "condition": "minecraft:survives_explosion"
         }
       ],
+      "functions": [
+        {
+          "function": "minecraft:furnace_smelt",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "function": "minecraft:set_components",
+          "components": {
+            "minecraft:custom_data": {
+              "auto_smelt_drops_xp": true,
+              "auto_smelt_xp": 1
+            }
+          },
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "enchantplus:tools/auto_smelt",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.1
+            }
+          ]
+        }
+      ],
       "entries": [
         {
           "type": "minecraft:item",


### PR DESCRIPTION
Blocks that are smelted when mined with auto-smelt tool now drop XP based on how much you would get from smelting them

EXP orbs can only have integer values so for results with <1 xp there is a chance for XP to drop.

i.e. if smelting gives 0.7 EXP there's a 70% for an orb of value 1 to drop.

Also added exclusivity with silk touch to prevent conflicts/weird interactions.
(though it does appear to work correctly, silk touch takes priority and no XP is dropped)