### PR TITLE
Fixed a broken background texture path by correcting "background" line in root.json

### DIFF
--- a/data/enchantplus/advancement/root.json
+++ b/data/enchantplus/advancement/root.json
@@ -12,7 +12,7 @@
       "fallback": "Discover a new power of enchantments",
       "color": "aqua"
     },
-    "background": "minecraft:textures/block/quartz_block_side.png",
+    "background": "minecraft:block/quartz_block_side",
     "frame": "task",
     "show_toast": true,
     "announce_to_chat": true,


### PR DESCRIPTION
Corrected the advancement background path from
"minecraft:textures/block/quartz_block_side.png"
to
"minecraft:block/quartz_block_side"
to fix a missing texture issue.