### PR TITLE
🪓  Timber Consistency

### DIFF
--- a/data/enchantplus/enchantment/axe/timber.json
+++ b/data/enchantplus/enchantment/axe/timber.json
@@ -24,7 +24,19 @@
                 "effect": {
                     "type": "minecraft:run_function",
                     "function": "enchantplus:actions/timber/place_hit_block_marker"
-                }
+                }, 
+                "requirements": {
+					"condition": "minecraft:entity_properties",
+					"entity": "this",
+					"predicate": {
+						"type_specific": {
+							"type": "minecraft:player",
+							"input": {
+								"sneak": false
+							}
+						}
+					}
+				}
             }
         ]
     }


### PR DESCRIPTION
### Changes
- Simply added the pre-existing predicate from miningplus to timber to make both enchantment consistent in behavior. 